### PR TITLE
Add Jest tests and CI workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,21 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main, work ]
+  pull_request:
+    branches: [ main, work ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # testing
+
+This repository demonstrates basic note management with tests using Jest.
+
+## Development
+
+Install dependencies (requires internet):
+
+```bash
+npm install
+```
+
+Run tests:
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "testing",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/src/notes.js
+++ b/src/notes.js
@@ -1,0 +1,20 @@
+let notes = [];
+
+function addNote(text) {
+  if (typeof text !== 'string' || !text.trim()) {
+    throw new Error('Note text must be a non-empty string');
+  }
+  const note = { id: notes.length + 1, text };
+  notes.push(note);
+  return note;
+}
+
+function getAllNotes() {
+  return notes.slice();
+}
+
+function clearNotes() {
+  notes = [];
+}
+
+module.exports = { addNote, getAllNotes, clearNotes };

--- a/test/notes.test.js
+++ b/test/notes.test.js
@@ -1,0 +1,20 @@
+const { addNote, getAllNotes, clearNotes } = require('../src/notes');
+
+describe('note management', () => {
+  beforeEach(() => {
+    clearNotes();
+  });
+
+  test('adds a note', () => {
+    const note = addNote('First note');
+    expect(note.id).toBe(1);
+    expect(note.text).toBe('First note');
+  });
+
+  test('retrieves all notes', () => {
+    addNote('Note 1');
+    addNote('Note 2');
+    const notes = getAllNotes();
+    expect(notes).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- set up Node project
- add basic note manager
- write Jest tests for note manager
- ignore node modules
- configure GitHub Actions to run tests

## Testing
- `npm test` *(fails: `jest` not found)*