### PR TITLE
Improve project robustness with tests and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@ coverage/
 # Other
 .DS_Store
 
+# Python artifacts
+__pycache__/
+*.py[cod]
+.pytest_cache/
+notes.db
+.venv/
+

--- a/README.md
+++ b/README.md
@@ -22,3 +22,12 @@ The `frontend/` directory holds a very small HTML page that interacts with the A
 - CRUD operations for notes and tags via REST endpoints
 - Notes can be associated with multiple tags
 - Data is stored in a SQLite database (`notes.db`)
+
+## Testing
+
+Run tests with `pytest` after installing the requirements:
+
+```bash
+pip install -r backend/requirements.txt
+pytest
+```

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,32 +2,37 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from typing import List, Optional
 import sqlite3
+import os
 
-DB_FILE = 'notes.db'
+DB_FILE = os.environ.get('NOTES_DB_FILE', 'notes.db')
+
+
+def init_db(db_file: str):
+    conn = sqlite3.connect(db_file)
+    cur = conn.cursor()
+    cur.execute('''CREATE TABLE IF NOT EXISTS tags (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT UNIQUE NOT NULL
+    )''')
+    cur.execute('''CREATE TABLE IF NOT EXISTS notes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        content TEXT NOT NULL
+    )''')
+    cur.execute('''CREATE TABLE IF NOT EXISTS note_tags (
+        note_id INTEGER NOT NULL,
+        tag_id INTEGER NOT NULL,
+        PRIMARY KEY(note_id, tag_id),
+        FOREIGN KEY(note_id) REFERENCES notes(id) ON DELETE CASCADE,
+        FOREIGN KEY(tag_id) REFERENCES tags(id) ON DELETE CASCADE
+    )''')
+    conn.commit()
+    conn.close()
 
 app = FastAPI()
 
 # Initialize database
-conn = sqlite3.connect(DB_FILE)
-cur = conn.cursor()
-cur.execute('''CREATE TABLE IF NOT EXISTS tags (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT UNIQUE NOT NULL
-)''')
-cur.execute('''CREATE TABLE IF NOT EXISTS notes (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    title TEXT NOT NULL,
-    content TEXT NOT NULL
-)''')
-cur.execute('''CREATE TABLE IF NOT EXISTS note_tags (
-    note_id INTEGER NOT NULL,
-    tag_id INTEGER NOT NULL,
-    PRIMARY KEY(note_id, tag_id),
-    FOREIGN KEY(note_id) REFERENCES notes(id) ON DELETE CASCADE,
-    FOREIGN KEY(tag_id) REFERENCES tags(id) ON DELETE CASCADE
-)''')
-conn.commit()
-conn.close()
+init_db(DB_FILE)
 
 class TagCreate(BaseModel):
     name: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,5 @@
 fastapi
 uvicorn
 pydantic
+pytest
+requests

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,40 @@
+import os
+import importlib
+import sqlite3
+import pytest
+from fastapi.testclient import TestClient
+
+# use temporary database for tests
+@pytest.fixture(scope="module")
+def client(tmp_path_factory):
+    db_path = tmp_path_factory.mktemp('data') / 'test.db'
+    os.environ['NOTES_DB_FILE'] = str(db_path)
+    # reload the app to ensure DB_FILE is read
+    main = importlib.import_module('backend.main')
+    importlib.reload(main)
+    main.init_db(main.DB_FILE)
+    with TestClient(main.app) as c:
+        yield c
+    # cleanup
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+
+def test_create_tag_and_note(client):
+    # create tag
+    res = client.post('/tags/', json={'name': 'work'})
+    assert res.status_code == 200
+    tag = res.json()
+
+    # create note with that tag
+    res = client.post('/notes/', json={'title': 'Title', 'content': 'Body', 'tag_ids': [tag['id']]})
+    assert res.status_code == 200
+    note = res.json()
+    assert note['title'] == 'Title'
+    assert len(note['tags']) == 1
+
+    # list notes
+    res = client.get('/notes/')
+    assert res.status_code == 200
+    notes = res.json()
+    assert len(notes) == 1


### PR DESCRIPTION
## Summary
- refactor backend DB initialization to allow alternate database files
- extend `.gitignore` to cover Python artifacts
- add API tests using `pytest` and update dependencies
- document how to run the tests

## Testing
- `python -m py_compile backend/main.py tests/test_api.py`
- `pytest -q` *(fails: command not found)*